### PR TITLE
feat(helm): support an existing Secret for the database connection URL

### DIFF
--- a/helm-unittests/test_secrets.py
+++ b/helm-unittests/test_secrets.py
@@ -25,3 +25,9 @@ class TestOxMasterPasswordSecret(SecretPasswords):
 
     def values(self, localpart: dict) -> dict:
         return {"openXchange": localpart}
+
+class TestDbConnectionStringSecret(SecretPasswords):
+    template_file = "templates/secret-db-connection-string.yaml"
+
+    def values(self, localpart: dict) -> dict:
+        return {"openXchange": localpart}

--- a/helm/ox-connector/README.md
+++ b/helm/ox-connector/README.md
@@ -30,12 +30,14 @@ A Helm chart for the ox-connector
 | openXchange.auth.existingSecret.name | string | `nil` | Name of an existing Secret that contains the OX Admin password. The value in "openXchange.auth.password" is ignored if this value is set. |
 | openXchange.auth.password | string | `nil` | Password of the OX Admin user. |
 | openXchange.auth.username | string | `"oxadminmaster"` | Username of the OX Admin user. The OX Admin user can create, modify, and delete contexts and must already exist. |
+| openXchange.database.existingSecret.keyMapping.OX_CONNECTOR_DB | string | `nil` | Key in the existing Secret that holds the connection URL. Defaults to the key the chart uses in its own Secret. |
+| openXchange.database.existingSecret.name | string | `nil` | Name of an existing Secret that contains the SQLAlchemy DB connection URL. The value in "openXchange.oxDbConnectionString" is ignored if this value is set. Providing the URL this way keeps the database password out of the rendered manifests. |
 | openXchange.domainName | string | `nil` | OX mail domain that the connector uses to generate email addresses. |
 | openXchange.logLevel | string | `"INFO"` | OX Connector log level. Choose from "DEBUG", "INFO", "WARNING", and "ERROR". |
 | openXchange.mappings.groupIdentifier | string | `"name"` | UDM group property that the connector uses as the unique group identifier in OX. |
 | openXchange.mappings.sharedAccountIdentifier | string | `"name"` | UDM shared account property that the connector uses as the unique shared account identifier in OX. |
 | openXchange.mappings.userIdentifier | string | `"username"` | UDM user property that the connector uses as the unique user identifier in OX. |
-| openXchange.oxDbConnectionString | string | `nil` | SQLAlchemy DB connection URL for the OX connector. |
+| openXchange.oxDbConnectionString | string | `nil` | SQLAlchemy DB connection URL for the OX connector. Ignored if "openXchange.database.existingSecret.name" is set. |
 | openXchange.oxDefaultContext | string | `"10"` | Default OX context for users. The context must already exist. |
 | openXchange.oxDeputyPermissions | bool | `false` | Enable provisioning of OX deputy permissions. |
 | openXchange.oxImapServer | string | `nil` | Default IMAP server for new users if no IMAP server is set on the user object. |

--- a/helm/ox-connector/templates/secret-db-connection-string.yaml
+++ b/helm/ox-connector/templates/secret-db-connection-string.yaml
@@ -3,6 +3,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 SPDX-FileCopyrightText: 2026 Univention GmbH
 */}}
 
+{{- if not (.Values.openXchange.database.existingSecret).name }}
 ---
 apiVersion: "v1"
 kind: "Secret"
@@ -17,4 +18,5 @@ metadata:
     | nindent 2 }}
 type: "Opaque"
 stringData:
-  OX_CONNECTOR_DB: {{ required "The parameter \".Values.openXchange.oxDbConnectionString\" is required." .Values.openXchange.oxDbConnectionString | quote }}
+  OX_CONNECTOR_DB: {{ required "Either \".Values.openXchange.oxDbConnectionString\" or \".Values.openXchange.database.existingSecret.name\" is required." .Values.openXchange.oxDbConnectionString | quote }}
+{{- end }}

--- a/helm/ox-connector/templates/statefulset.yaml
+++ b/helm/ox-connector/templates/statefulset.yaml
@@ -80,9 +80,12 @@ spec:
           envFrom:
              - configMapRef:
                  name: {{ include "common.names.fullname" . }}
-             - secretRef:
-                 name: {{ include "common.names.fullname" . }}-db-connection-string
           env:
+            - name: "OX_CONNECTOR_DB"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nubus-common.secrets.name" (dict "existingSecret" .Values.openXchange.database.existingSecret "defaultNameSuffix" "db-connection-string" "context" .) | quote }}
+                  key: {{ include "nubus-common.secrets.key" (dict "existingSecret" .Values.openXchange.database.existingSecret "key" "OX_CONNECTOR_DB") | quote }}
             - name: PROVISIONING_API_RESYNC_ENABLED
               value: {{ .Values.provisioningApi.resync.enabled | quote }}
             {{- if .Values.provisioningApi.resync.enabled }}
@@ -126,14 +129,17 @@ spec:
                 secretKeyRef:
                   key: {{ include "nubus-common.secrets.key" (dict "existingSecret" .Values.openXchange.auth.existingSecret "key" "password") | quote }}
                   name: {{ include "nubus-common.secrets.name" (dict "existingSecret" .Values.openXchange.auth.existingSecret "defaultNameSuffix" "ox-master-password" "context" .) | quote }}
+            - name: "OX_CONNECTOR_DB"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nubus-common.secrets.name" (dict "existingSecret" .Values.openXchange.database.existingSecret "defaultNameSuffix" "db-connection-string" "context" .) | quote }}
+                  key: {{ include "nubus-common.secrets.key" (dict "existingSecret" .Values.openXchange.database.existingSecret "key" "OX_CONNECTOR_DB") | quote }}
           {{- with .Values.oxConnector.extraEnvVars }}
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" . }}
-            - secretRef:
-                name: {{ include "common.names.fullname" . }}-db-connection-string
           volumeMounts:
             - name: {{ include "common.names.fullname" . }}-ox-contexts
               mountPath: /etc/ox-secrets

--- a/helm/ox-connector/values.yaml
+++ b/helm/ox-connector/values.yaml
@@ -109,7 +109,18 @@ openXchange:
   # -- Enable provisioning of OX shared accounts.
   oxSharedAccount: true
   # -- SQLAlchemy DB connection URL for the OX connector.
+  # Ignored if "openXchange.database.existingSecret.name" is set.
   oxDbConnectionString: null
+  database:
+    existingSecret:
+      # -- Name of an existing Secret that contains the SQLAlchemy DB connection URL.
+      # The value in "openXchange.oxDbConnectionString" is ignored if this value is set.
+      # Providing the URL this way keeps the database password out of the rendered manifests.
+      name: null
+      keyMapping:
+        # -- Key in the existing Secret that holds the connection URL.
+        # Defaults to the key the chart uses in its own Secret.
+        OX_CONNECTOR_DB: null
   mappings:
     # -- UDM user property that the connector uses as the unique user identifier in OX.
     userIdentifier: "username"


### PR DESCRIPTION
## Problem

The chart renders `openXchange.oxDbConnectionString` verbatim into its `<release>-db-connection-string` Secret:

```yaml
stringData:
  OX_CONNECTOR_DB: {{ required "..." .Values.openXchange.oxDbConnectionString | quote }}
```

That URL contains the database password, so a deployment that keeps its credentials outside the chart — external secret manager, sealed secrets, SOPS, or a GitOps repo where rendered manifests are reviewed — has no way to supply the connection string without the password landing in the manifests. Every other credential in this chart already has a way out: `openXchange.auth.existingSecret`, `provisioningApi.auth.existingSecret`, `provisioningApi.resync.auth.existingSecret`. The connection string is the one that does not.

Concretely, in openDesk the workaround today is a password-less DSN plus `PGPASSWORD` injected through `oxConnector.extraEnvVars`, which works but splits one credential across two places.

## Change

`openXchange.database.existingSecret`, following the same convention as `openXchange.auth.existingSecret`:

```yaml
openXchange:
  oxDbConnectionString: null   # ignored when the Secret below is named
  database:
    existingSecret:
      name: null
      keyMapping:
        OX_CONNECTOR_DB: null
```

- `secret-db-connection-string.yaml` is skipped when a name is set, so the chart writes no connection string of its own.
- Both the `init-db` init container and the connector container now read `OX_CONNECTOR_DB` from an explicit `secretKeyRef`, resolved through `nubus-common.secrets.name` / `nubus-common.secrets.key`, instead of an `envFrom` of the chart's own Secret. `envFrom` cannot remap keys, so the explicit form is what makes `keyMapping` meaningful — and it matches how this chart already wires `OX_MASTER_PASSWORD` and `PROVISIONING_API_PASSWORD`.
- `oxDbConnectionString` stays required when no Secret is named; the message now mentions both ways.

## Testing

`helm template`, with `helm lint` clean and the README regenerated with helm-docs:

| Case | Secrets rendered | `OX_CONNECTOR_DB` env |
| --- | --- | --- |
| default (`oxDbConnectionString` set) | 3 — including `t-ox-connector-db-connection-string` | `secretKeyRef` → `t-ox-connector-db-connection-string` / `OX_CONNECTOR_DB` in both containers |
| `database.existingSecret.name=my-dsn` | 2 — the chart's own is gone | → `my-dsn` / `OX_CONNECTOR_DB` |
| … plus `keyMapping.OX_CONNECTOR_DB=dsn` | 2 | → `my-dsn` / `dsn` |
| neither set | — | `Either ".Values.openXchange.oxDbConnectionString" or ".Values.openXchange.database.existingSecret.name" is required` |

The default case is behaviour-identical to before: same Secret name, same key, same env var — only the mechanism moves from `envFrom` to an explicit `env` entry.

`helm-unittests/test_secrets.py` gains a `TestDbConnectionStringSecret` case alongside the existing `TestProvisioningSecret` / `TestOxMasterPasswordSecret`.

## Notes

Happy to adjust the naming — `openXchange.database.existingSecret` was chosen to sit next to `openXchange.auth.existingSecret` without turning the existing scalar `oxDbConnectionString` into a mapping, which would have been a breaking change for current values files.
